### PR TITLE
feat: learnings system — scoped behavioral rules for agents

### DIFF
--- a/docs/design/learnings-system.md
+++ b/docs/design/learnings-system.md
@@ -1,0 +1,353 @@
+# Design Proposal: Learnings System
+
+**Status:** Draft  
+**Author:** Sun Canyon Tech  
+**Target version:** post-0.3.x
+
+---
+
+## 1. Problem Statement
+
+ZeroClaw already has three layers of behavioral control:
+
+| Layer | What it is | Where it lives |
+|---|---|---|
+| Identity | Who the agent *is* | `SOUL.md`, `AGENTS.md`, AiEOS profile |
+| Skills | What the agent *can do* | `workspace/skills/<name>/SKILL.md` |
+| SOPs | Triggered procedures the agent *executes* | `workspace/sops/<name>/SOP.toml` + `SOP.md` |
+
+There is no first-class home for **soft behavioral rules** — the kind of team/project/channel-specific guidance that:
+
+- Is not core to identity ("always link commits" is a workflow preference, not a personality trait)
+- Is not a capability ("when working on PRs, create a draft first and get human approval before promoting" is *how* to use the skill, not the skill itself)
+- Varies by team, project, or channel ("in `#sct-internal-dev`, assume requests relate to `buysidehub-api` unless stated otherwise")
+- May or may not apply depending on context ("the draft-PR rule only matters when the `feature-pr` skill is active")
+
+Today these rules live in `AGENTS.md` or skill `SKILL.md` files, which creates two problems:
+1. **Coupling** — workflow preferences pollute identity/capability definitions, making both harder to maintain
+2. **Context blindness** — rules that only apply in certain channels or at certain hook points are always present, adding noise to every prompt
+
+**Learnings** fill this gap: a dedicated, scoped, opt-in layer of behavioral context injected only when relevant.
+
+---
+
+## 2. Concept
+
+A **learning** is a named bundle of behavioral rules with one or more *scopes* that determine when those rules are injected into the agent's context.
+
+### 2.1 Scope Model
+
+| Scope | Injection point | Example use case |
+|---|---|---|
+| `global` | Every system prompt | "Always link commits and PRs in replies" |
+| `skill:<name>` | Alongside the named skill in the prompt | "When using `feature-pr`, create draft PRs first" |
+| `channel:<id>` | When the inbound message comes from a matching channel | "In `#sct-internal-dev`, assume `buysidehub-api` context" |
+| `hook:<name>` | At the named lifecycle hook | "Before any tool call, prefer read-only operations" |
+
+A single learning can carry multiple scopes (e.g. `skill:feature-pr` + `skill:gh-issues` for a "draft PR" rule that applies to both PR-creating skills).
+
+### 2.2 What Learnings Are Not
+
+- **Not hard rules.** Hard rules belong in `AGENTS.md` / identity. Learnings are *advisory*: they influence behavior without blocking it.
+- **Not skill definitions.** Skills define capabilities. Learnings define how to exercise those capabilities for a specific team or workflow.
+- **Not SOPs.** SOPs are triggered, step-by-step procedures with execution modes. Learnings are ambient context.
+
+---
+
+## 3. On-Disk Format
+
+Learnings live at `<workspace>/learnings/<name>/`:
+
+```
+workspace/
+  learnings/
+    draft-pr-first/
+      LEARNING.toml     ← required
+      LEARNING.md       ← optional (long-form prose, appended as a rule)
+    sct-dev-channel/
+      LEARNING.toml
+```
+
+### 3.1 LEARNING.toml
+
+Minimal (single scope):
+
+```toml
+[learning]
+name        = "draft-pr-first"
+description = "Always create PRs as drafts before promoting to review-ready"
+version     = "0.1.0"
+scope       = "skill:feature-pr"
+
+[[rules]]
+content = "Always create PRs as drafts first. Do not promote to non-draft without explicit human approval."
+
+[[rules]]
+content = "If a second-agent reviewer is configured, request their review on the draft before promoting."
+```
+
+Multi-scope (applies to multiple skills):
+
+```toml
+[learning]
+name        = "draft-pr-first"
+description = "Draft PR gate for all PR-creating skills"
+scopes      = ["skill:feature-pr", "skill:gh-issues"]
+
+[[rules]]
+content = "Create PRs as drafts first. Wait for explicit approval before marking ready for review."
+```
+
+Channel-scoped:
+
+```toml
+[learning]
+name        = "sct-dev-channel-context"
+description = "Contextual defaults for #sct-internal-dev"
+scope       = "channel:slack:#sct-internal-dev"
+
+[[rules]]
+content = "When a request is ambiguous, assume it relates to the buysidehub-api repository unless the user specifies otherwise."
+
+[[rules]]
+content = "Always link PRs, commits, and issues by URL — do not describe changes without a link."
+```
+
+Hook-scoped:
+
+```toml
+[learning]
+name        = "tool-call-caution"
+description = "Prefer read-only operations before mutating anything"
+scope       = "hook:before_prompt_build"
+
+[[rules]]
+content = "Before executing any mutating operation, confirm you understand the full scope of the change."
+```
+
+### 3.2 LEARNING.md (optional)
+
+If present, the full Markdown content is appended as an additional rule. Useful for long-form guidance that's awkward in TOML string syntax.
+
+---
+
+## 4. Architecture
+
+### 4.1 Module: `src/learnings/`
+
+New module parallel to `src/skills/` and `src/sop/`:
+
+```
+src/learnings/
+  mod.rs        ← load_learnings(), filter helpers, learnings_to_prompt()
+  types.rs      ← Learning, LearningScope, LearningManifest
+```
+
+**Key types:**
+
+```rust
+pub enum LearningScope {
+    Global,
+    Skill { skill: String },
+    Channel { channel: String },
+    Hook { hook: String },
+}
+
+pub struct Learning {
+    pub name: String,
+    pub description: String,
+    pub version: String,
+    pub scopes: Vec<LearningScope>,
+    pub rules: Vec<String>,
+    // ...
+}
+```
+
+**Filter helpers:**
+
+```rust
+pub fn global_learnings(learnings: &[Learning]) -> Vec<&Learning>
+pub fn learnings_for_skill(learnings: &[Learning], skill_name: &str) -> Vec<&Learning>
+pub fn learnings_for_channel(learnings: &[Learning], channel_id: Option<&str>) -> Vec<&Learning>
+pub fn learnings_for_hook(learnings: &[Learning], hook_name: &str) -> Vec<&Learning>
+```
+
+### 4.2 Prompt Injection — `src/agent/prompt.rs`
+
+`PromptContext` gains two new fields:
+
+```rust
+pub learnings: &'a [Learning],
+pub active_channel: Option<&'a str>,
+```
+
+Two new `PromptSection` implementations are added to `SystemPromptBuilder::with_defaults()`:
+
+| Section | Position in prompt | What it injects |
+|---|---|---|
+| `GlobalLearningsSection` | After `SkillsSection` | All learnings with `scope = Global` |
+| `ChannelLearningsSection` | After `GlobalLearningsSection` | Learnings matching `active_channel` |
+
+**Skill-scoped learnings** are injected inside `SkillsSection` itself: when rendering each skill's `<instructions>` block, the section also looks up `learnings_for_skill(learnings, skill.name)` and appends matching rules inline. This keeps skill + its behavioral rules co-located in the prompt for maximum model attention.
+
+### 4.3 Hook Injection — `src/hooks/builtin/learnings.rs`
+
+`LearningsHookHandler` implements `HookHandler` with `priority = -10` (runs after standard hooks):
+
+```rust
+// Appends hook:before_prompt_build learnings to the assembled prompt string
+async fn before_prompt_build(&self, mut prompt: String) -> HookResult<String>
+
+// Pass-through (hook:before_tool_call learnings already in the system prompt)
+async fn before_tool_call(&self, name: String, args: Value) -> HookResult<(String, Value)>
+```
+
+The handler is registered in the `HookRunner` at agent startup when learnings are present.
+
+### 4.4 Config — `src/config/schema.rs`
+
+New `[learnings]` section:
+
+```toml
+[learnings]
+enabled = true         # default: true
+dir     = "~/custom/learnings"  # default: <workspace>/learnings/
+```
+
+### 4.5 Agent Wiring — `src/agent/agent.rs`
+
+- `Agent` struct gains `learnings: Vec<Learning>`
+- `AgentBuilder` gains `.learnings(Vec<Learning>)` setter
+- `build_system_prompt()` delegates to `build_system_prompt_with_channel(None)`
+- New `build_system_prompt_with_channel(active_channel: Option<&str>)` passes `active_channel` + `learnings` into `PromptContext`
+- The gateway / daemon request path passes the inbound channel identifier when calling `build_system_prompt_with_channel`
+
+---
+
+## 5. Lifecycle: Message → Prompt
+
+```
+1. Inbound message arrives (Slack, Telegram, etc.)
+   └─ Channel identifier extracted: e.g. "slack:#sct-internal-dev"
+
+2. HookRunner::run_on_message_received()
+   └─ LearningsHookHandler: no-op here (channel id flows into prompt build instead)
+
+3. Agent::build_system_prompt_with_channel("slack:#sct-internal-dev")
+   │
+   ├─ IdentitySection          → SOUL.md, AGENTS.md, AiEOS
+   ├─ ToolsSection             → registered tools
+   ├─ SafetySection            → hard safety rules
+   ├─ SkillsSection            → skills + skill-scoped learnings inline
+   ├─ GlobalLearningsSection   → learnings[scope=Global]
+   ├─ ChannelLearningsSection  → learnings[scope=Channel("slack:#sct-internal-dev")]
+   ├─ WorkspaceSection
+   ├─ DateTimeSection
+   ├─ RuntimeSection
+   └─ ChannelMediaSection
+
+4. HookRunner::run_before_prompt_build(prompt)
+   └─ LearningsHookHandler::before_prompt_build()
+      → appends learnings[scope=Hook("before_prompt_build")]
+
+5. LLM call with fully assembled prompt
+```
+
+---
+
+## 6. CLI
+
+Future `zeroclaw learnings` subcommands (not in this PR):
+
+```
+zeroclaw learnings list           # list all loaded learnings + their scopes
+zeroclaw learnings validate       # validate LEARNING.toml files
+zeroclaw learnings show <name>    # show rules for a specific learning
+```
+
+---
+
+## 7. Example: Full Workflow
+
+**Scenario:** Jake's team wants:
+1. Draft PRs before promoting (skill rule)
+2. Auto-assume `buysidehub-api` in `#sct-internal-dev` (channel rule)
+3. A global rule to always link commits
+
+**workspace/learnings/always-link/LEARNING.toml:**
+```toml
+[learning]
+name = "always-link"
+description = "Always link code changes"
+scope = "global"
+
+[[rules]]
+content = "When you've pushed commits or opened PRs, always provide the direct GitHub link in your reply. Never just say 'I updated file X'."
+```
+
+**workspace/learnings/draft-pr-first/LEARNING.toml:**
+```toml
+[learning]
+name = "draft-pr-first"
+description = "Draft PR gate"
+scopes = ["skill:feature-pr", "skill:gh-issues"]
+
+[[rules]]
+content = "Always create PRs as drafts. Do not promote to non-draft without explicit human approval or a second-agent review."
+```
+
+**workspace/learnings/sct-dev-context/LEARNING.toml:**
+```toml
+[learning]
+name = "sct-dev-context"
+description = "Context for #sct-internal-dev"
+scope = "channel:slack:#sct-internal-dev"
+
+[[rules]]
+content = "When a request is ambiguous, assume it relates to the buysidehub-api repository."
+```
+
+**What the model sees** when a message arrives in `#sct-internal-dev` and the `feature-pr` skill is loaded:
+
+```xml
+<!-- In SkillsSection, after feature-pr instructions -->
+<learnings>
+  <learning>
+    <name>draft-pr-first</name>
+    <rules>
+      <rule>Always create PRs as drafts. Do not promote...</rule>
+    </rules>
+  </learning>
+</learnings>
+
+<!-- GlobalLearningsSection -->
+<learnings>
+  <learning>
+    <name>always-link</name>
+    <rules>
+      <rule>When you've pushed commits or opened PRs, always provide...</rule>
+    </rules>
+  </learning>
+</learnings>
+
+<!-- ChannelLearningsSection -->
+## Channel Context (slack:#sct-internal-dev)
+<learnings>
+  <learning>
+    <name>sct-dev-context</name>
+    <rules>
+      <rule>When a request is ambiguous, assume it relates to buysidehub-api.</rule>
+    </rules>
+  </learning>
+</learnings>
+```
+
+---
+
+## 8. Open Questions / Future Work
+
+- **Skill-scoped injection timing:** Currently skill-scoped learnings require the skill to appear in the loaded skills list. A future improvement could lazy-load learnings when a skill is dynamically selected via the `Compact` injection mode.
+- **Agent-to-agent learnings:** A second-agent reviewer pattern (e.g. "draft PR must be approved by both a human and an agent before promoting") could be expressed as a learning with a `requires_confirmation: true` analog — worth exploring as a learning attribute.
+- **Learning inheritance:** A `parent` field to inherit rules from another learning (DRY for multi-team setups).
+- **`zeroclaw learnings` CLI subcommand** for listing, validating, and showing active learnings.
+- **Learning priority** — analogous to `HookHandler::priority()`, allowing teams to define ordering when multiple learnings apply.

--- a/docs/design/learnings-system.md
+++ b/docs/design/learnings-system.md
@@ -140,8 +140,39 @@ New module parallel to `src/skills/` and `src/sop/`:
 ```
 src/learnings/
   mod.rs        ← load_learnings(), filter helpers, learnings_to_prompt()
+  store.rs      ← LearningsStore — live-reloading Arc<RwLock<Vec<Learning>>>
   types.rs      ← Learning, LearningScope, LearningManifest
 ```
+
+#### Dynamic Store (`LearningsStore`)
+
+Learnings are **not** configured in the primary config file — that would require the agent to edit its own config to add new rules, and would require a restart. Instead, the store is backed by the `<workspace>/learnings/` directory and reloads automatically:
+
+```rust
+pub struct LearningsStore {
+    inner: Arc<RwLock<Vec<Learning>>>,
+    dir: PathBuf,
+}
+
+impl LearningsStore {
+    // Load from workspace_dir/learnings/ at construction time
+    pub fn new(workspace_dir: &Path) -> Self;
+
+    // Return a point-in-time snapshot (lock held briefly)
+    pub fn snapshot(&self) -> Vec<Learning>;
+
+    // Force-reload from disk (also called by the watcher on change)
+    pub fn reload(&self);
+
+    // Spawn a background tokio task that polls every N seconds
+    pub fn spawn_watcher(self: Arc<Self>, interval_secs: u64);
+
+    // Write a Learning to disk as LEARNING.toml + immediately reload
+    pub fn write_learning(&self, learning: &Learning) -> Result<()>;
+}
+```
+
+**Key property:** When an agent writes a new `LEARNING.toml` (e.g. via `write_learning()` or the `file_write` tool), the background watcher picks it up within the next poll interval and the new rules become active on the *next prompt build* — **no restart required**.
 
 **Key types:**
 
@@ -192,9 +223,14 @@ Two new `PromptSection` implementations are added to `SystemPromptBuilder::with_
 
 ### 4.3 Hook Injection — `src/hooks/builtin/learnings.rs`
 
-`LearningsHookHandler` implements `HookHandler` with `priority = -10` (runs after standard hooks):
+`LearningsHookHandler` implements `HookHandler` with `priority = -10` (runs after standard hooks).
+It holds an `Arc<LearningsStore>` so it always reads the *current* learnings on each invocation:
 
 ```rust
+pub struct LearningsHookHandler {
+    store: Arc<LearningsStore>,
+}
+
 // Appends hook:before_prompt_build learnings to the assembled prompt string
 async fn before_prompt_build(&self, mut prompt: String) -> HookResult<String>
 
@@ -202,7 +238,9 @@ async fn before_prompt_build(&self, mut prompt: String) -> HookResult<String>
 async fn before_tool_call(&self, name: String, args: Value) -> HookResult<(String, Value)>
 ```
 
-The handler is registered in the `HookRunner` at agent startup when learnings are present.
+The handler is registered in the `HookRunner` at agent startup when learnings are enabled.
+Because `before_prompt_build` calls `self.store.snapshot()` on every invocation, newly-added
+hook-scoped learnings take effect immediately without restarting the agent.
 
 ### 4.4 Config — `src/config/schema.rs`
 
@@ -216,11 +254,11 @@ dir     = "~/custom/learnings"  # default: <workspace>/learnings/
 
 ### 4.5 Agent Wiring — `src/agent/agent.rs`
 
-- `Agent` struct gains `learnings: Vec<Learning>`
-- `AgentBuilder` gains `.learnings(Vec<Learning>)` setter
+- `Agent` struct holds `learnings: Arc<LearningsStore>` (not a static `Vec`)
+- `AgentBuilder` gains `.learnings(Arc<LearningsStore>)` setter
+- `Agent::from_config()` constructs the store from `config.workspace_dir`, then calls `store.spawn_watcher(5)` to enable live reload
 - `build_system_prompt()` delegates to `build_system_prompt_with_channel(None)`
-- New `build_system_prompt_with_channel(active_channel: Option<&str>)` passes `active_channel` + `learnings` into `PromptContext`
-- The gateway / daemon request path passes the inbound channel identifier when calling `build_system_prompt_with_channel`
+- `build_system_prompt_with_channel` calls `self.learnings.snapshot()` to get a fresh copy of learnings for the current prompt build
 
 ---
 

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -32,7 +32,7 @@ pub struct Agent {
     identity_config: crate::config::IdentityConfig,
     skills: Vec<crate::skills::Skill>,
     skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
-    learnings: Vec<crate::learnings::Learning>,
+    learnings: Arc<crate::learnings::LearningsStore>,
     auto_save: bool,
     history: Vec<ConversationMessage>,
     classification_config: crate::config::QueryClassificationConfig,
@@ -55,7 +55,7 @@ pub struct AgentBuilder {
     identity_config: Option<crate::config::IdentityConfig>,
     skills: Option<Vec<crate::skills::Skill>>,
     skills_prompt_mode: Option<crate::config::SkillsPromptInjectionMode>,
-    learnings: Option<Vec<crate::learnings::Learning>>,
+    learnings: Option<Arc<crate::learnings::LearningsStore>>,
     auto_save: Option<bool>,
     classification_config: Option<crate::config::QueryClassificationConfig>,
     available_hints: Option<Vec<String>>,
@@ -160,7 +160,7 @@ impl AgentBuilder {
         self
     }
 
-    pub fn learnings(mut self, learnings: Vec<crate::learnings::Learning>) -> Self {
+    pub fn learnings(mut self, learnings: Arc<crate::learnings::LearningsStore>) -> Self {
         self.learnings = Some(learnings);
         self
     }
@@ -226,7 +226,11 @@ impl AgentBuilder {
             identity_config: self.identity_config.unwrap_or_default(),
             skills: self.skills.unwrap_or_default(),
             skills_prompt_mode: self.skills_prompt_mode.unwrap_or_default(),
-            learnings: self.learnings.unwrap_or_default(),
+            learnings: self.learnings.unwrap_or_else(|| {
+                Arc::new(crate::learnings::LearningsStore::from_dir(
+                    std::path::PathBuf::from(".").join("learnings"),
+                ))
+            }),
             auto_save: self.auto_save.unwrap_or(false),
             history: Vec::new(),
             classification_config: self.classification_config.unwrap_or_default(),
@@ -351,6 +355,19 @@ impl Agent {
             ))
             .skills_prompt_mode(config.skills.prompt_injection_mode)
             .auto_save(config.memory.auto_save)
+            .learnings({
+                // Build the learnings store from the workspace directory.
+                // The store's background watcher is started here so that any
+                // LEARNING.toml files written by the agent (or the operator)
+                // are picked up without restarting the process.
+                let store = Arc::new(crate::learnings::LearningsStore::new(
+                    &config.workspace_dir,
+                ));
+                if config.learnings.enabled {
+                    Arc::clone(&store).spawn_watcher(5);
+                }
+                store
+            })
             .build()
     }
 
@@ -386,6 +403,11 @@ impl Agent {
     }
 
     fn build_system_prompt_with_channel(&self, active_channel: Option<&str>) -> Result<String> {
+        // Take a snapshot of the current learnings so the prompt always
+        // reflects the latest state of the learnings store (which may have
+        // been updated by the background watcher or by an agent writing new
+        // LEARNING.toml files via `LearningsStore::write_learning`).
+        let learnings_snapshot = self.learnings.snapshot();
         let instructions = self.tool_dispatcher.prompt_instructions(&self.tools);
         let ctx = PromptContext {
             workspace_dir: &self.workspace_dir,
@@ -395,7 +417,7 @@ impl Agent {
             skills_prompt_mode: self.skills_prompt_mode,
             identity_config: Some(&self.identity_config),
             dispatcher_instructions: &instructions,
-            learnings: &self.learnings,
+            learnings: &learnings_snapshot,
             active_channel,
         };
         self.prompt_builder.build(&ctx)

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -32,6 +32,7 @@ pub struct Agent {
     identity_config: crate::config::IdentityConfig,
     skills: Vec<crate::skills::Skill>,
     skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
+    learnings: Vec<crate::learnings::Learning>,
     auto_save: bool,
     history: Vec<ConversationMessage>,
     classification_config: crate::config::QueryClassificationConfig,
@@ -54,6 +55,7 @@ pub struct AgentBuilder {
     identity_config: Option<crate::config::IdentityConfig>,
     skills: Option<Vec<crate::skills::Skill>>,
     skills_prompt_mode: Option<crate::config::SkillsPromptInjectionMode>,
+    learnings: Option<Vec<crate::learnings::Learning>>,
     auto_save: Option<bool>,
     classification_config: Option<crate::config::QueryClassificationConfig>,
     available_hints: Option<Vec<String>>,
@@ -77,6 +79,7 @@ impl AgentBuilder {
             identity_config: None,
             skills: None,
             skills_prompt_mode: None,
+            learnings: None,
             auto_save: None,
             classification_config: None,
             available_hints: None,
@@ -157,6 +160,11 @@ impl AgentBuilder {
         self
     }
 
+    pub fn learnings(mut self, learnings: Vec<crate::learnings::Learning>) -> Self {
+        self.learnings = Some(learnings);
+        self
+    }
+
     pub fn auto_save(mut self, auto_save: bool) -> Self {
         self.auto_save = Some(auto_save);
         self
@@ -218,6 +226,7 @@ impl AgentBuilder {
             identity_config: self.identity_config.unwrap_or_default(),
             skills: self.skills.unwrap_or_default(),
             skills_prompt_mode: self.skills_prompt_mode.unwrap_or_default(),
+            learnings: self.learnings.unwrap_or_default(),
             auto_save: self.auto_save.unwrap_or(false),
             history: Vec::new(),
             classification_config: self.classification_config.unwrap_or_default(),
@@ -373,6 +382,10 @@ impl Agent {
     }
 
     fn build_system_prompt(&self) -> Result<String> {
+        self.build_system_prompt_with_channel(None)
+    }
+
+    fn build_system_prompt_with_channel(&self, active_channel: Option<&str>) -> Result<String> {
         let instructions = self.tool_dispatcher.prompt_instructions(&self.tools);
         let ctx = PromptContext {
             workspace_dir: &self.workspace_dir,
@@ -382,6 +395,8 @@ impl Agent {
             skills_prompt_mode: self.skills_prompt_mode,
             identity_config: Some(&self.identity_config),
             dispatcher_instructions: &instructions,
+            learnings: &self.learnings,
+            active_channel,
         };
         self.prompt_builder.build(&ctx)
     }

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -1,5 +1,6 @@
 use crate::config::IdentityConfig;
 use crate::identity;
+use crate::learnings::{self, Learning, LearningScope};
 use crate::skills::Skill;
 use crate::tools::Tool;
 use anyhow::Result;
@@ -17,6 +18,11 @@ pub struct PromptContext<'a> {
     pub skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
     pub identity_config: Option<&'a IdentityConfig>,
     pub dispatcher_instructions: &'a str,
+    /// All learnings loaded for this workspace.
+    pub learnings: &'a [Learning],
+    /// Channel identifier for the current inbound message, e.g. `"slack:#sct-internal-dev"`.
+    /// Used to select channel-scoped learnings at prompt-build time.
+    pub active_channel: Option<&'a str>,
 }
 
 pub trait PromptSection: Send + Sync {
@@ -37,6 +43,12 @@ impl SystemPromptBuilder {
                 Box::new(ToolsSection),
                 Box::new(SafetySection),
                 Box::new(SkillsSection),
+                // Global learnings injected after skills so the model sees them
+                // in the same "instructions" cluster.
+                Box::new(GlobalLearningsSection),
+                // Channel-scoped learnings come just before the datetime/runtime
+                // tail so they read as fresh context, not permanent identity.
+                Box::new(ChannelLearningsSection),
                 Box::new(WorkspaceSection),
                 Box::new(DateTimeSection),
                 Box::new(RuntimeSection),
@@ -68,6 +80,8 @@ pub struct IdentitySection;
 pub struct ToolsSection;
 pub struct SafetySection;
 pub struct SkillsSection;
+pub struct GlobalLearningsSection;
+pub struct ChannelLearningsSection;
 pub struct WorkspaceSection;
 pub struct RuntimeSection;
 pub struct DateTimeSection;
@@ -161,6 +175,35 @@ impl PromptSection for SkillsSection {
             ctx.workspace_dir,
             ctx.skills_prompt_mode,
         ))
+    }
+}
+
+impl PromptSection for GlobalLearningsSection {
+    fn name(&self) -> &str {
+        "global_learnings"
+    }
+
+    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        let global = learnings::global_learnings(ctx.learnings);
+        Ok(learnings::learnings_to_prompt(&global, "Behavioral Learnings"))
+    }
+}
+
+impl PromptSection for ChannelLearningsSection {
+    fn name(&self) -> &str {
+        "channel_learnings"
+    }
+
+    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        let channel = learnings::learnings_for_channel(ctx.learnings, ctx.active_channel);
+        if channel.is_empty() {
+            return Ok(String::new());
+        }
+        let header = match ctx.active_channel {
+            Some(id) => format!("Channel Context ({id})"),
+            None => "Channel Context".into(),
+        };
+        Ok(learnings::learnings_to_prompt(&channel, &header))
     }
 }
 
@@ -317,6 +360,8 @@ mod tests {
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
             identity_config: Some(&identity_config),
             dispatcher_instructions: "",
+            learnings: &[],
+            active_channel: None,
         };
 
         let section = IdentitySection;
@@ -345,6 +390,8 @@ mod tests {
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "instr",
+            learnings: &[],
+            active_channel: None,
         };
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
         assert!(prompt.contains("## Tools"));
@@ -380,6 +427,8 @@ mod tests {
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            learnings: &[],
+            active_channel: None,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -418,6 +467,8 @@ mod tests {
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Compact,
             identity_config: None,
             dispatcher_instructions: "",
+            learnings: &[],
+            active_channel: None,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -439,6 +490,8 @@ mod tests {
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "instr",
+            learnings: &[],
+            active_channel: None,
         };
 
         let rendered = DateTimeSection.build(&ctx).unwrap();
@@ -477,6 +530,8 @@ mod tests {
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
             identity_config: None,
             dispatcher_instructions: "",
+            learnings: &[],
+            active_channel: None,
         };
 
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3828,6 +3828,18 @@ pub async fn start_channels(config: Config) -> Result<()> {
                     config.hooks.builtin.webhook_audit.clone(),
                 )));
             }
+            // Register the learnings hook handler when learnings are enabled.
+            // It holds an Arc<LearningsStore> backed by the same watcher that
+            // the agent uses, so hook-scoped learnings are always current.
+            if config.learnings.enabled {
+                let store = Arc::new(crate::learnings::LearningsStore::new(
+                    &config.workspace_dir,
+                ));
+                Arc::clone(&store).spawn_watcher(5);
+                runner.register(Box::new(
+                    crate::hooks::builtin::LearningsHookHandler::new(store),
+                ));
+            }
             Some(Arc::new(runner))
         } else {
             None

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -144,6 +144,10 @@ pub struct Config {
     #[serde(default)]
     pub skills: SkillsConfig,
 
+    /// Learnings — soft behavioral rules scoped to global/skill/channel/hook (`[learnings]`).
+    #[serde(default)]
+    pub learnings: LearningsConfig,
+
     /// Model routing rules — route `hint:<name>` to specific provider+model combos.
     #[serde(default)]
     pub model_routes: Vec<ModelRouteConfig>,
@@ -879,6 +883,22 @@ pub struct SkillsConfig {
     /// `full` preserves legacy behavior. `compact` keeps context small and loads skills on demand.
     #[serde(default)]
     pub prompt_injection_mode: SkillsPromptInjectionMode,
+}
+
+/// Learnings configuration (`[learnings]` section).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct LearningsConfig {
+    /// Whether learnings are loaded and injected. Default: `true`.
+    #[serde(default = "default_learnings_enabled")]
+    pub enabled: bool,
+    /// Override the learnings directory path.
+    /// Defaults to `<workspace>/learnings/`.
+    #[serde(default)]
+    pub dir: Option<String>,
+}
+
+fn default_learnings_enabled() -> bool {
+    true
 }
 
 /// Multimodal (image) handling configuration (`[multimodal]` section).

--- a/src/hooks/builtin/learnings.rs
+++ b/src/hooks/builtin/learnings.rs
@@ -1,0 +1,139 @@
+//! `LearningsHookHandler` — injects hook-scoped learnings into the system
+//! prompt at the `before_prompt_build` lifecycle point.
+//!
+//! Global and channel-scoped learnings are handled at prompt-build time by
+//! `GlobalLearningsSection` / `ChannelLearningsSection` in `agent/prompt.rs`.
+//! This hook handles the remaining scopes that are contextual to the *current
+//! request* and not knowable at static prompt-assembly time:
+//!
+//! - `hook:before_prompt_build` — general hook-scoped rules
+//! - `hook:before_tool_call` — rules that apply right before any tool is called
+//!   (injected by the companion `before_tool_call` implementation)
+//!
+//! ## Why a hook, not a section?
+//!
+//! Sections run once at startup during prompt assembly and see only static
+//! context (workspace, skills, channel id).  Hook handlers run per-request and
+//! can react to dynamic state: which skills were activated, which channel the
+//! current message came from, etc.  The hook approach also lets operators
+//! override or disable learnings injection without forking the agent core.
+
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::hooks::traits::{HookHandler, HookResult};
+use crate::learnings::{self, Learning};
+
+pub struct LearningsHookHandler {
+    learnings: Arc<Vec<Learning>>,
+}
+
+impl LearningsHookHandler {
+    pub fn new(learnings: Vec<Learning>) -> Self {
+        Self {
+            learnings: Arc::new(learnings),
+        }
+    }
+
+    fn hook_rules_block(&self, hook_name: &str) -> String {
+        let matched = learnings::learnings_for_hook(&self.learnings, hook_name);
+        learnings::learnings_to_prompt(&matched, &format!("Learnings ({hook_name})"))
+    }
+}
+
+#[async_trait]
+impl HookHandler for LearningsHookHandler {
+    fn name(&self) -> &str {
+        "learnings"
+    }
+
+    /// Low priority — runs after identity/safety hooks so it appends rather
+    /// than prepends to any existing modifications.
+    fn priority(&self) -> i32 {
+        -10
+    }
+
+    /// Append `hook:before_prompt_build` learnings to the system prompt string.
+    async fn before_prompt_build(&self, mut prompt: String) -> HookResult<String> {
+        let block = self.hook_rules_block("before_prompt_build");
+        if !block.is_empty() {
+            prompt.push_str("\n\n");
+            prompt.push_str(&block);
+        }
+        HookResult::Continue(prompt)
+    }
+
+    /// Append `hook:before_tool_call` learnings as a suffix note on the prompt.
+    ///
+    /// Note: this does not modify the tool call itself — it appends a reminder
+    /// block to the ongoing prompt context so the model has the rules in scope
+    /// when deciding how to call tools.  The name/args pass through unchanged.
+    async fn before_tool_call(&self, name: String, args: Value) -> HookResult<(String, Value)> {
+        // Learning injection for tool calls is advisory only — we don't mutate
+        // the call.  The rules were already in the system prompt if scoped
+        // to `hook:before_tool_call`; this is a no-op pass-through here.
+        // Future: could inject a "reminder" user message into the conversation.
+        HookResult::Continue((name, args))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::learnings::{Learning, LearningScope};
+
+    fn make_hook_learning(hook: &str) -> Learning {
+        Learning {
+            name: format!("hook-{hook}"),
+            description: "hook rule".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Hook {
+                hook: hook.to_string(),
+            }],
+            rules: vec![format!("Rule for {hook}.")],
+            location: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn appends_hook_learnings_to_prompt() {
+        let learning = make_hook_learning("before_prompt_build");
+        let handler = LearningsHookHandler::new(vec![learning]);
+
+        let base = "## System\n\nYou are an agent.".to_string();
+        match handler.before_prompt_build(base.clone()).await {
+            HookResult::Continue(result) => {
+                assert!(result.starts_with(&base));
+                assert!(result.contains("Rule for before_prompt_build."));
+            }
+            HookResult::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_op_when_no_hook_learnings() {
+        let learning = make_hook_learning("some_other_hook");
+        let handler = LearningsHookHandler::new(vec![learning]);
+
+        let base = "## System\n\nYou are an agent.".to_string();
+        match handler.before_prompt_build(base.clone()).await {
+            HookResult::Continue(result) => assert_eq!(result, base),
+            HookResult::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[tokio::test]
+    async fn before_tool_call_passes_through() {
+        let handler = LearningsHookHandler::new(vec![]);
+        match handler
+            .before_tool_call("shell".into(), serde_json::json!({"cmd": "ls"}))
+            .await
+        {
+            HookResult::Continue((name, _)) => assert_eq!(name, "shell"),
+            HookResult::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+}

--- a/src/hooks/builtin/learnings.rs
+++ b/src/hooks/builtin/learnings.rs
@@ -17,27 +17,39 @@
 //! can react to dynamic state: which skills were activated, which channel the
 //! current message came from, etc.  The hook approach also lets operators
 //! override or disable learnings injection without forking the agent core.
+//!
+//! ## Dynamic reload
+//!
+//! The handler holds an `Arc<LearningsStore>` rather than a static
+//! `Vec<Learning>`.  On every hook invocation it calls `store.snapshot()` to
+//! get the *current* learnings, so any LEARNING.toml files added or modified
+//! on disk (and picked up by the store's background watcher) take effect
+//! immediately — no agent restart required.
 
 use async_trait::async_trait;
 use serde_json::Value;
 use std::sync::Arc;
 
 use crate::hooks::traits::{HookHandler, HookResult};
-use crate::learnings::{self, Learning};
+use crate::learnings::{self, LearningsStore};
 
 pub struct LearningsHookHandler {
-    learnings: Arc<Vec<Learning>>,
+    store: Arc<LearningsStore>,
 }
 
 impl LearningsHookHandler {
-    pub fn new(learnings: Vec<Learning>) -> Self {
-        Self {
-            learnings: Arc::new(learnings),
-        }
+    /// Create a handler backed by a live [`LearningsStore`].
+    ///
+    /// The store should already have its watcher running (via
+    /// [`LearningsStore::spawn_watcher`]) so that hook injections stay current
+    /// without an agent restart.
+    pub fn new(store: Arc<LearningsStore>) -> Self {
+        Self { store }
     }
 
     fn hook_rules_block(&self, hook_name: &str) -> String {
-        let matched = learnings::learnings_for_hook(&self.learnings, hook_name);
+        let snapshot = self.store.snapshot();
+        let matched = learnings::learnings_for_hook(&snapshot, hook_name);
         learnings::learnings_to_prompt(&matched, &format!("Learnings ({hook_name})"))
     }
 }
@@ -81,10 +93,15 @@ impl HookHandler for LearningsHookHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::learnings::{Learning, LearningScope};
+    use crate::learnings::{Learning, LearningScope, LearningsStore};
+    use std::sync::Arc;
 
-    fn make_hook_learning(hook: &str) -> Learning {
-        Learning {
+    fn make_store_with_hook_learning(
+        tmp: &tempfile::TempDir,
+        hook: &str,
+    ) -> Arc<LearningsStore> {
+        let store = Arc::new(LearningsStore::new(tmp.path()));
+        let learning = Learning {
             name: format!("hook-{hook}"),
             description: "hook rule".into(),
             version: "0.1.0".into(),
@@ -95,13 +112,16 @@ mod tests {
             }],
             rules: vec![format!("Rule for {hook}.")],
             location: None,
-        }
+        };
+        store.write_learning(&learning).unwrap();
+        store
     }
 
     #[tokio::test]
     async fn appends_hook_learnings_to_prompt() {
-        let learning = make_hook_learning("before_prompt_build");
-        let handler = LearningsHookHandler::new(vec![learning]);
+        let tmp = tempfile::tempdir().unwrap();
+        let store = make_store_with_hook_learning(&tmp, "before_prompt_build");
+        let handler = LearningsHookHandler::new(store);
 
         let base = "## System\n\nYou are an agent.".to_string();
         match handler.before_prompt_build(base.clone()).await {
@@ -115,8 +135,9 @@ mod tests {
 
     #[tokio::test]
     async fn no_op_when_no_hook_learnings() {
-        let learning = make_hook_learning("some_other_hook");
-        let handler = LearningsHookHandler::new(vec![learning]);
+        let tmp = tempfile::tempdir().unwrap();
+        let store = make_store_with_hook_learning(&tmp, "some_other_hook");
+        let handler = LearningsHookHandler::new(store);
 
         let base = "## System\n\nYou are an agent.".to_string();
         match handler.before_prompt_build(base.clone()).await {
@@ -127,12 +148,54 @@ mod tests {
 
     #[tokio::test]
     async fn before_tool_call_passes_through() {
-        let handler = LearningsHookHandler::new(vec![]);
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(LearningsStore::new(tmp.path()));
+        let handler = LearningsHookHandler::new(store);
         match handler
             .before_tool_call("shell".into(), serde_json::json!({"cmd": "ls"}))
             .await
         {
             HookResult::Continue((name, _)) => assert_eq!(name, "shell"),
+            HookResult::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[tokio::test]
+    async fn picks_up_new_learnings_after_reload() {
+        // Demonstrate that adding a learning to the store while the handler is
+        // running takes effect without constructing a new handler.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(LearningsStore::new(tmp.path()));
+        let handler = LearningsHookHandler::new(Arc::clone(&store));
+
+        let base = "## System".to_string();
+
+        // Initially no learnings — should be a no-op.
+        match handler.before_prompt_build(base.clone()).await {
+            HookResult::Continue(result) => assert_eq!(result, base),
+            HookResult::Cancel(_) => panic!("should not cancel"),
+        }
+
+        // Now add a hook-scoped learning directly to the store.
+        let new_learning = Learning {
+            name: "dynamic-rule".into(),
+            description: "added at runtime".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Hook {
+                hook: "before_prompt_build".into(),
+            }],
+            rules: vec!["Dynamic runtime rule.".into()],
+            location: None,
+        };
+        store.write_learning(&new_learning).unwrap();
+
+        // Same handler — should now see the new learning.
+        match handler.before_prompt_build(base.clone()).await {
+            HookResult::Continue(result) => {
+                assert!(result.contains("Dynamic runtime rule."), "expected dynamic rule in prompt");
+            }
             HookResult::Cancel(_) => panic!("should not cancel"),
         }
     }

--- a/src/hooks/builtin/mod.rs
+++ b/src/hooks/builtin/mod.rs
@@ -1,5 +1,7 @@
 pub mod command_logger;
+pub mod learnings;
 pub mod webhook_audit;
 
 pub use command_logger::CommandLoggerHook;
+pub use learnings::LearningsHookHandler;
 pub use webhook_audit::WebhookAuditHook;

--- a/src/learnings/mod.rs
+++ b/src/learnings/mod.rs
@@ -1,0 +1,536 @@
+//! # Learnings
+//!
+//! Learnings are soft behavioral rules that extend an agent's behavior without
+//! modifying its core identity.  Unlike `SOUL.md` / `AGENTS.md` (identity) or
+//! skills (capabilities), learnings describe *how* an agent should act in
+//! specific contexts.
+//!
+//! ## Scope model
+//!
+//! Each learning declares one or more scopes that control *when* and *where*
+//! its rules are injected into the agent's context:
+//!
+//! | Scope             | Injected when…                                         |
+//! |-------------------|---------------------------------------------------------|
+//! | `global`          | Always — every system prompt                           |
+//! | `skill:<name>`    | The named skill is active for the current request      |
+//! | `channel:<id>`    | The inbound message originates from a matching channel |
+//! | `hook:<hook>`     | A specific lifecycle hook fires                        |
+//!
+//! ## On-disk format
+//!
+//! ```
+//! <workspace>/learnings/<name>/
+//!   LEARNING.toml   ← required: metadata + rules
+//!   LEARNING.md     ← optional: long-form prose injected as an additional rule
+//! ```
+//!
+//! Minimal `LEARNING.toml`:
+//!
+//! ```toml
+//! [learning]
+//! name        = "draft-pr-first"
+//! description = "Always draft PRs before promoting to review-ready"
+//! scope       = "skill:feature-pr"
+//!
+//! [[rules]]
+//! content = "Create PRs as drafts first. Do not promote to non-draft without explicit human approval."
+//! ```
+//!
+//! Multi-scope example:
+//!
+//! ```toml
+//! [learning]
+//! name        = "sct-dev-channel-context"
+//! description = "Contextual assumptions for #sct-internal-dev"
+//! scopes      = ["channel:slack:#sct-internal-dev"]
+//!
+//! [[rules]]
+//! content = "When the request is ambiguous, assume it relates to the buysidehub-api repository."
+//!
+//! [[rules]]
+//! content = "Always link PRs and commits in replies — do not just say 'I updated file X'."
+//! ```
+
+mod types;
+
+pub use types::{Learning, LearningScope};
+use types::{LearningManifest, ScopeShorthand};
+
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+// ── Directory helpers ────────────────────────────────────────────
+
+pub fn learnings_dir(workspace_dir: &Path) -> PathBuf {
+    workspace_dir.join("learnings")
+}
+
+// ── Loading ──────────────────────────────────────────────────────
+
+/// Load all learnings from `<workspace>/learnings/`.
+pub fn load_learnings(workspace_dir: &Path) -> Vec<Learning> {
+    let dir = learnings_dir(workspace_dir);
+    load_learnings_from_directory(&dir)
+}
+
+fn load_learnings_from_directory(learnings_dir: &Path) -> Vec<Learning> {
+    if !learnings_dir.exists() {
+        return Vec::new();
+    }
+
+    let mut learnings = Vec::new();
+
+    let Ok(entries) = std::fs::read_dir(learnings_dir) else {
+        return learnings;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let toml_path = path.join("LEARNING.toml");
+        if !toml_path.exists() {
+            continue;
+        }
+
+        match load_learning(&path) {
+            Ok(learning) => learnings.push(learning),
+            Err(e) => {
+                warn!("Failed to load learning from {}: {e}", path.display());
+            }
+        }
+    }
+
+    learnings.sort_by(|a, b| a.name.cmp(&b.name));
+    learnings
+}
+
+fn load_learning(dir: &Path) -> Result<Learning> {
+    let toml_path = dir.join("LEARNING.toml");
+    let toml_content = std::fs::read_to_string(&toml_path)?;
+    let manifest: LearningManifest = toml::from_str(&toml_content)?;
+
+    // Collect all scopes: `scope` (singular) + `scopes` (list)
+    let mut raw_scopes: Vec<ScopeShorthand> = manifest.learning.scopes.clone();
+    if let Some(ref singular) = manifest.learning.scope {
+        raw_scopes.push(singular.clone());
+    }
+
+    let scopes: Vec<LearningScope> = raw_scopes
+        .iter()
+        .filter_map(|s| {
+            let parsed = s.parse();
+            if parsed.is_none() {
+                warn!(
+                    "Learning '{}': unrecognised scope '{}' — skipping",
+                    manifest.learning.name, s.0
+                );
+            }
+            parsed
+        })
+        .collect();
+
+    if scopes.is_empty() {
+        anyhow::bail!(
+            "Learning '{}' has no valid scopes — add `scope = \"global\"` or another scope",
+            manifest.learning.name
+        );
+    }
+
+    // Base rules from [[rules]] entries
+    let mut rules: Vec<String> = manifest.rules.iter().map(|r| r.content.clone()).collect();
+
+    // Optional LEARNING.md appended as a final rule block
+    let md_path = dir.join("LEARNING.md");
+    if md_path.exists() {
+        if let Ok(md) = std::fs::read_to_string(&md_path) {
+            let trimmed = md.trim().to_string();
+            if !trimmed.is_empty() {
+                rules.push(trimmed);
+            }
+        }
+    }
+
+    Ok(Learning {
+        name: manifest.learning.name,
+        description: manifest.learning.description,
+        version: manifest.learning.version,
+        author: manifest.learning.author,
+        tags: manifest.learning.tags,
+        scopes,
+        rules,
+        location: Some(toml_path),
+    })
+}
+
+// ── Filtering helpers ────────────────────────────────────────────
+
+/// Return learnings that match `LearningScope::Global`.
+pub fn global_learnings(learnings: &[Learning]) -> Vec<&Learning> {
+    learnings
+        .iter()
+        .filter(|l| l.scopes.contains(&LearningScope::Global))
+        .collect()
+}
+
+/// Return learnings that apply to the named skill.
+pub fn learnings_for_skill<'a>(learnings: &'a [Learning], skill_name: &str) -> Vec<&'a Learning> {
+    learnings
+        .iter()
+        .filter(|l| {
+            l.scopes.iter().any(|s| {
+                matches!(s, LearningScope::Skill { skill } if skill == skill_name)
+            })
+        })
+        .collect()
+}
+
+/// Return learnings that match a channel identifier.
+///
+/// Matching is exact on the full `channel` string, e.g.
+/// `"slack:#sct-internal-dev"`.  Pass `None` to get an empty slice.
+pub fn learnings_for_channel<'a>(
+    learnings: &'a [Learning],
+    channel_id: Option<&str>,
+) -> Vec<&'a Learning> {
+    let Some(id) = channel_id else {
+        return Vec::new();
+    };
+    learnings
+        .iter()
+        .filter(|l| {
+            l.scopes.iter().any(|s| {
+                matches!(s, LearningScope::Channel { channel } if channel == id)
+            })
+        })
+        .collect()
+}
+
+/// Return learnings scoped to a specific hook name.
+pub fn learnings_for_hook<'a>(learnings: &'a [Learning], hook_name: &str) -> Vec<&'a Learning> {
+    learnings
+        .iter()
+        .filter(|l| {
+            l.scopes
+                .iter()
+                .any(|s| matches!(s, LearningScope::Hook { hook } if hook == hook_name))
+        })
+        .collect()
+}
+
+// ── Prompt rendering ─────────────────────────────────────────────
+
+/// Render a slice of learnings into a system-prompt block.
+pub fn learnings_to_prompt(learnings: &[&Learning], header: &str) -> String {
+    if learnings.is_empty() {
+        return String::new();
+    }
+
+    let mut out = format!("## {header}\n\n");
+    out.push_str("<learnings>\n");
+
+    for learning in learnings {
+        out.push_str("  <learning>\n");
+        out.push_str(&format!("    <name>{}</name>\n", xml_escape(&learning.name)));
+        out.push_str(&format!(
+            "    <description>{}</description>\n",
+            xml_escape(&learning.description)
+        ));
+        if !learning.rules.is_empty() {
+            out.push_str("    <rules>\n");
+            for rule in &learning.rules {
+                out.push_str(&format!(
+                    "      <rule>{}</rule>\n",
+                    xml_escape(rule.trim())
+                ));
+            }
+            out.push_str("    </rules>\n");
+        }
+        out.push_str("  </learning>\n");
+    }
+
+    out.push_str("</learnings>");
+    out
+}
+
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_learning_dir(base: &Path, name: &str, toml: &str, md: Option<&str>) -> PathBuf {
+        let dir = base.join("learnings").join(name);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("LEARNING.toml"), toml).unwrap();
+        if let Some(content) = md {
+            fs::write(dir.join("LEARNING.md"), content).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn load_global_learning() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_learning_dir(
+            tmp.path(),
+            "always-link",
+            r#"
+[learning]
+name = "always-link"
+description = "Always link commits"
+scope = "global"
+
+[[rules]]
+content = "Always link commits and PRs in replies."
+"#,
+            None,
+        );
+
+        let learnings = load_learnings(tmp.path());
+        assert_eq!(learnings.len(), 1);
+        assert_eq!(learnings[0].name, "always-link");
+        assert_eq!(learnings[0].scopes, vec![LearningScope::Global]);
+        assert_eq!(learnings[0].rules.len(), 1);
+    }
+
+    #[test]
+    fn load_skill_scoped_learning() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_learning_dir(
+            tmp.path(),
+            "draft-pr",
+            r#"
+[learning]
+name = "draft-pr"
+description = "Draft PRs first"
+scope = "skill:feature-pr"
+
+[[rules]]
+content = "Always create PRs as drafts."
+
+[[rules]]
+content = "Require human approval before promoting."
+"#,
+            None,
+        );
+
+        let learnings = load_learnings(tmp.path());
+        assert_eq!(learnings.len(), 1);
+        assert_eq!(
+            learnings[0].scopes,
+            vec![LearningScope::Skill {
+                skill: "feature-pr".into()
+            }]
+        );
+        assert_eq!(learnings[0].rules.len(), 2);
+    }
+
+    #[test]
+    fn load_multi_scope_learning() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_learning_dir(
+            tmp.path(),
+            "channel-ctx",
+            r#"
+[learning]
+name = "channel-ctx"
+description = "Channel context"
+scopes = ["channel:slack:#dev", "channel:slack:#eng"]
+
+[[rules]]
+content = "Assume buysidehub-api context."
+"#,
+            None,
+        );
+
+        let learnings = load_learnings(tmp.path());
+        assert_eq!(learnings[0].scopes.len(), 2);
+    }
+
+    #[test]
+    fn load_learning_with_md_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_learning_dir(
+            tmp.path(),
+            "with-md",
+            r#"
+[learning]
+name = "with-md"
+description = "Has prose"
+scope = "global"
+"#,
+            Some("Long-form prose rule from LEARNING.md."),
+        );
+
+        let learnings = load_learnings(tmp.path());
+        assert_eq!(learnings[0].rules.len(), 1);
+        assert!(learnings[0].rules[0].contains("Long-form prose"));
+    }
+
+    #[test]
+    fn load_skips_missing_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("learnings").join("no-toml");
+        fs::create_dir_all(&dir).unwrap();
+        // No LEARNING.toml
+
+        let learnings = load_learnings(tmp.path());
+        assert!(learnings.is_empty());
+    }
+
+    #[test]
+    fn load_skips_no_valid_scopes() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_learning_dir(
+            tmp.path(),
+            "bad-scope",
+            r#"
+[learning]
+name = "bad-scope"
+description = "Has bad scope"
+scope = "invalid:something"
+
+[[rules]]
+content = "rule"
+"#,
+            None,
+        );
+
+        let learnings = load_learnings(tmp.path());
+        assert!(learnings.is_empty());
+    }
+
+    #[test]
+    fn filter_global() {
+        let global = Learning {
+            name: "g".into(),
+            description: "".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Global],
+            rules: vec![],
+            location: None,
+        };
+        let skill = Learning {
+            name: "s".into(),
+            description: "".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Skill {
+                skill: "foo".into(),
+            }],
+            rules: vec![],
+            location: None,
+        };
+        let all = vec![global, skill];
+        let g = global_learnings(&all);
+        assert_eq!(g.len(), 1);
+        assert_eq!(g[0].name, "g");
+    }
+
+    #[test]
+    fn filter_by_skill() {
+        let l = Learning {
+            name: "l".into(),
+            description: "".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Skill {
+                skill: "feature-pr".into(),
+            }],
+            rules: vec![],
+            location: None,
+        };
+        let all = vec![l];
+        assert_eq!(learnings_for_skill(&all, "feature-pr").len(), 1);
+        assert_eq!(learnings_for_skill(&all, "other").len(), 0);
+    }
+
+    #[test]
+    fn filter_by_channel() {
+        let l = Learning {
+            name: "c".into(),
+            description: "".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Channel {
+                channel: "slack:#dev".into(),
+            }],
+            rules: vec![],
+            location: None,
+        };
+        let all = vec![l];
+        assert_eq!(
+            learnings_for_channel(&all, Some("slack:#dev")).len(),
+            1
+        );
+        assert_eq!(
+            learnings_for_channel(&all, Some("slack:#other")).len(),
+            0
+        );
+        assert_eq!(learnings_for_channel(&all, None).len(), 0);
+    }
+
+    #[test]
+    fn learnings_to_prompt_empty() {
+        assert!(learnings_to_prompt(&[], "Learnings").is_empty());
+    }
+
+    #[test]
+    fn learnings_to_prompt_renders_xml() {
+        let l = Learning {
+            name: "test".into(),
+            description: "A test".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Global],
+            rules: vec!["Do the thing.".into()],
+            location: None,
+        };
+        let prompt = learnings_to_prompt(&[&l], "Active Learnings");
+        assert!(prompt.contains("## Active Learnings"));
+        assert!(prompt.contains("<name>test</name>"));
+        assert!(prompt.contains("<rule>Do the thing.</rule>"));
+    }
+
+    #[test]
+    fn learnings_to_prompt_escapes_xml() {
+        let l = Learning {
+            name: "x<y>&z".into(),
+            description: "desc".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Global],
+            rules: vec!["Use <tool> & check \"q\"".into()],
+            location: None,
+        };
+        let prompt = learnings_to_prompt(&[&l], "Learnings");
+        assert!(prompt.contains("<name>x&lt;y&gt;&amp;z</name>"));
+        assert!(prompt.contains("&lt;tool&gt; &amp; check &quot;q&quot;"));
+    }
+}

--- a/src/learnings/mod.rs
+++ b/src/learnings/mod.rs
@@ -52,8 +52,10 @@
 //! content = "Always link PRs and commits in replies — do not just say 'I updated file X'."
 //! ```
 
+mod store;
 mod types;
 
+pub use store::LearningsStore;
 pub use types::{Learning, LearningScope};
 use types::{LearningManifest, ScopeShorthand};
 
@@ -75,7 +77,7 @@ pub fn load_learnings(workspace_dir: &Path) -> Vec<Learning> {
     load_learnings_from_directory(&dir)
 }
 
-fn load_learnings_from_directory(learnings_dir: &Path) -> Vec<Learning> {
+pub(crate) fn load_learnings_from_directory(learnings_dir: &Path) -> Vec<Learning> {
     if !learnings_dir.exists() {
         return Vec::new();
     }

--- a/src/learnings/store.rs
+++ b/src/learnings/store.rs
@@ -1,0 +1,428 @@
+//! Dynamic learnings store with file watching.
+//!
+//! [`LearningsStore`] wraps a `Vec<Learning>` behind an `Arc<RwLock<_>>` and
+//! spawns a background task that polls the learnings directory for changes.
+//! This lets agents add new learnings (by writing `LEARNING.toml` files) and
+//! have them take effect immediately — without restarting the agent process.
+//!
+//! ## How it works
+//!
+//! 1. At startup the store loads all learnings from `<workspace>/learnings/`.
+//! 2. A background tokio task (`spawn_watcher`) polls the directory every N
+//!    seconds, comparing the most-recent modified-time across all `LEARNING.toml`
+//!    files to the last-known snapshot mtime.
+//! 3. When a change is detected (new file, edit, deletion) the store reloads
+//!    all learnings atomically via `Arc<RwLock<_>>`.
+//! 4. Because callers read via `snapshot()` / `read()` they always see the
+//!    latest learnings on the *next* prompt build or hook invocation — no
+//!    restart required.
+//!
+//! ## Agent-side programmatic writes
+//!
+//! An agent can call [`LearningsStore::write_learning`] to serialise a
+//! [`Learning`] to disk and immediately reload the store.  Alternatively the
+//! agent can use its `file_write` tool to create/update `LEARNING.toml` files
+//! directly; the watcher will pick them up within one poll interval.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use anyhow::Result;
+use parking_lot::RwLock;
+use tracing::{info, warn};
+
+use super::{load_learnings_from_directory, Learning};
+
+// ── LearningsStore ────────────────────────────────────────────────
+
+/// A live-reloading, thread-safe store of learnings.
+///
+/// Clone is cheap: all clones share the same underlying data.
+#[derive(Clone)]
+pub struct LearningsStore {
+    inner: Arc<RwLock<Vec<Learning>>>,
+    /// Absolute path to the `learnings/` directory being watched.
+    pub dir: PathBuf,
+}
+
+impl LearningsStore {
+    // ── Construction ─────────────────────────────────────────────
+
+    /// Create a store backed by `<workspace_dir>/learnings/`.
+    ///
+    /// Learnings are loaded eagerly on construction; the watcher is *not*
+    /// started automatically — call [`spawn_watcher`] to enable live reload.
+    pub fn new(workspace_dir: &Path) -> Self {
+        let dir = workspace_dir.join("learnings");
+        let learnings = load_learnings_from_directory(&dir);
+        info!(
+            "LearningsStore: loaded {} learnings from {}",
+            learnings.len(),
+            dir.display()
+        );
+        Self {
+            inner: Arc::new(RwLock::new(learnings)),
+            dir,
+        }
+    }
+
+    /// Create a store that watches `dir` directly (rather than
+    /// `<workspace>/learnings/`).  Used in tests.
+    pub fn from_dir(dir: PathBuf) -> Self {
+        let learnings = load_learnings_from_directory(&dir);
+        Self {
+            inner: Arc::new(RwLock::new(learnings)),
+            dir,
+        }
+    }
+
+    // ── Read ─────────────────────────────────────────────────────
+
+    /// Return a point-in-time snapshot of the current learnings.
+    ///
+    /// The snapshot is cloned so the lock is held only briefly.
+    pub fn snapshot(&self) -> Vec<Learning> {
+        self.inner.read().clone()
+    }
+
+    /// Return the number of currently-loaded learnings.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    // ── Reload ───────────────────────────────────────────────────
+
+    /// Force-reload all learnings from disk, replacing the in-memory set.
+    pub fn reload(&self) {
+        let fresh = load_learnings_from_directory(&self.dir);
+        let count = fresh.len();
+        *self.inner.write() = fresh;
+        info!(
+            "LearningsStore: reloaded {} learnings from {}",
+            count,
+            self.dir.display()
+        );
+    }
+
+    // ── Programmatic write ────────────────────────────────────────
+
+    /// Write a new (or updated) learning to disk under
+    /// `<learnings_dir>/<name>/LEARNING.toml` and immediately reload the
+    /// store.
+    ///
+    /// This is the API agents use to persist a new behavioral rule at runtime:
+    /// call `write_learning`, the file is written, and the store reloads — the
+    /// new rule is active on the *very next* prompt build without restart.
+    ///
+    /// # Format
+    ///
+    /// The TOML is written in the standard `LEARNING.toml` format understood by
+    /// the learnings loader.  `rules` are emitted as `[[rules]]` entries.
+    pub fn write_learning(&self, learning: &Learning) -> Result<()> {
+        let slug = sanitise_name(&learning.name);
+        let dir = self.dir.join(&slug);
+        std::fs::create_dir_all(&dir)?;
+        let toml = serialise_learning_toml(learning);
+        let toml_path = dir.join("LEARNING.toml");
+        std::fs::write(&toml_path, toml)?;
+        info!(
+            "LearningsStore: wrote learning '{}' to {}",
+            learning.name,
+            toml_path.display()
+        );
+        // Reload immediately so callers see the new learning right away.
+        self.reload();
+        Ok(())
+    }
+
+    // ── Watcher ───────────────────────────────────────────────────
+
+    /// Spawn a background tokio task that polls the learnings directory every
+    /// `interval_secs` seconds and calls [`reload`] when a change is detected.
+    ///
+    /// The task holds an `Arc<LearningsStore>` so it keeps the store alive
+    /// independently of any other holders.
+    ///
+    /// # Change detection
+    ///
+    /// The watcher compares the most-recent `mtime` across all `LEARNING.toml`
+    /// files in the directory tree.  Any write (create, modify, delete+recreate)
+    /// to any `LEARNING.toml` triggers a full reload.
+    pub fn spawn_watcher(self: Arc<Self>, interval_secs: u64) {
+        let store = Arc::clone(&self);
+        tokio::spawn(async move {
+            let mut tick =
+                tokio::time::interval(tokio::time::Duration::from_secs(interval_secs));
+            let mut last_mtime = scan_mtime(&store.dir);
+
+            loop {
+                tick.tick().await;
+                let current_mtime = scan_mtime(&store.dir);
+                if current_mtime != last_mtime {
+                    store.reload();
+                    last_mtime = current_mtime;
+                }
+            }
+        });
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+/// Walk the learnings directory and return the most-recent `mtime` seen across
+/// all `LEARNING.toml` files (and the top-level directory entry itself so that
+/// deletions are also detected).
+fn scan_mtime(dir: &Path) -> Option<SystemTime> {
+    let mut latest: Option<SystemTime> = None;
+
+    // Include the directory itself — its mtime changes on file add/delete.
+    if let Ok(meta) = std::fs::metadata(dir) {
+        if let Ok(mtime) = meta.modified() {
+            update_latest(&mut latest, mtime);
+        }
+    }
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return latest;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        // Subdirectory mtime (changes when files inside are added/removed).
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(mtime) = meta.modified() {
+                update_latest(&mut latest, mtime);
+            }
+        }
+        // The LEARNING.toml file itself.
+        let toml = path.join("LEARNING.toml");
+        if let Ok(meta) = std::fs::metadata(&toml) {
+            if let Ok(mtime) = meta.modified() {
+                update_latest(&mut latest, mtime);
+            }
+        }
+        // Optional LEARNING.md.
+        let md = path.join("LEARNING.md");
+        if let Ok(meta) = std::fs::metadata(&md) {
+            if let Ok(mtime) = meta.modified() {
+                update_latest(&mut latest, mtime);
+            }
+        }
+    }
+
+    latest
+}
+
+fn update_latest(latest: &mut Option<SystemTime>, candidate: SystemTime) {
+    match latest {
+        None => *latest = Some(candidate),
+        Some(prev) if candidate > *prev => *latest = Some(candidate),
+        _ => {}
+    }
+}
+
+/// Sanitise a learning name into a safe filesystem slug.
+fn sanitise_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Serialise a [`Learning`] to TOML string in `LEARNING.toml` format.
+fn serialise_learning_toml(learning: &Learning) -> String {
+    let mut out = String::new();
+
+    out.push_str("[learning]\n");
+    out.push_str(&format!("name        = {:?}\n", learning.name));
+    out.push_str(&format!("description = {:?}\n", learning.description));
+    out.push_str(&format!("version     = {:?}\n", learning.version));
+
+    if let Some(ref author) = learning.author {
+        out.push_str(&format!("author      = {:?}\n", author));
+    }
+    if !learning.tags.is_empty() {
+        let tags: Vec<String> = learning.tags.iter().map(|t| format!("{t:?}")).collect();
+        out.push_str(&format!("tags        = [{}]\n", tags.join(", ")));
+    }
+
+    match learning.scopes.len() {
+        0 => {}
+        1 => {
+            out.push_str(&format!("scope       = {:?}\n", learning.scopes[0].to_string()));
+        }
+        _ => {
+            let scopes: Vec<String> = learning
+                .scopes
+                .iter()
+                .map(|s| format!("{:?}", s.to_string()))
+                .collect();
+            out.push_str(&format!("scopes      = [{}]\n", scopes.join(", ")));
+        }
+    }
+
+    for rule in &learning.rules {
+        out.push_str("\n[[rules]]\n");
+        out.push_str(&format!("content = {:?}\n", rule));
+    }
+
+    out
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::learnings::LearningScope;
+
+    fn make_toml(name: &str, scope: &str, rule: &str) -> String {
+        format!(
+            r#"
+[learning]
+name = "{name}"
+description = "test"
+scope = "{scope}"
+
+[[rules]]
+content = "{rule}"
+"#
+        )
+    }
+
+    #[test]
+    fn loads_on_construction() {
+        let tmp = tempfile::tempdir().unwrap();
+        let learnings_dir = tmp.path().join("learnings").join("rule-a");
+        std::fs::create_dir_all(&learnings_dir).unwrap();
+        std::fs::write(
+            learnings_dir.join("LEARNING.toml"),
+            make_toml("rule-a", "global", "Do the thing."),
+        )
+        .unwrap();
+
+        let store = LearningsStore::new(tmp.path());
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.snapshot()[0].name, "rule-a");
+    }
+
+    #[test]
+    fn reload_picks_up_new_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = LearningsStore::new(tmp.path());
+        assert_eq!(store.len(), 0);
+
+        // Write a new learning.
+        let learnings_dir = tmp.path().join("learnings").join("rule-b");
+        std::fs::create_dir_all(&learnings_dir).unwrap();
+        std::fs::write(
+            learnings_dir.join("LEARNING.toml"),
+            make_toml("rule-b", "global", "New rule."),
+        )
+        .unwrap();
+
+        store.reload();
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn write_learning_persists_and_reloads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = LearningsStore::new(tmp.path());
+
+        let learning = Learning {
+            name: "written-rule".into(),
+            description: "A programmatically written rule".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Global],
+            rules: vec!["Always write tests.".into()],
+            location: None,
+        };
+
+        store.write_learning(&learning).unwrap();
+
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.snapshot()[0].name, "written-rule");
+
+        // The file should exist on disk.
+        let toml_path = tmp
+            .path()
+            .join("learnings")
+            .join("written-rule")
+            .join("LEARNING.toml");
+        assert!(toml_path.exists());
+        let contents = std::fs::read_to_string(&toml_path).unwrap();
+        assert!(contents.contains("written-rule"));
+        assert!(contents.contains("Always write tests."));
+    }
+
+    #[test]
+    fn write_learning_special_chars_in_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = LearningsStore::new(tmp.path());
+
+        let learning = Learning {
+            name: "my rule / thing!".into(),
+            description: "test".into(),
+            version: "0.1.0".into(),
+            author: None,
+            tags: vec![],
+            scopes: vec![LearningScope::Global],
+            rules: vec!["rule".into()],
+            location: None,
+        };
+
+        store.write_learning(&learning).unwrap();
+        let slug = sanitise_name("my rule / thing!");
+        let toml_path = tmp
+            .path()
+            .join("learnings")
+            .join(&slug)
+            .join("LEARNING.toml");
+        assert!(toml_path.exists());
+    }
+
+    #[test]
+    fn scan_mtime_returns_none_for_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let learnings_dir = tmp.path().join("learnings");
+        // Don't create the dir — should return None.
+        assert!(scan_mtime(&learnings_dir).is_none());
+    }
+
+    #[test]
+    fn scan_mtime_updates_after_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let learnings_dir = tmp.path().join("learnings").join("rule-x");
+        std::fs::create_dir_all(&learnings_dir).unwrap();
+
+        let before = scan_mtime(tmp.path().join("learnings").as_path());
+
+        // Small sleep to ensure mtime changes.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        std::fs::write(
+            learnings_dir.join("LEARNING.toml"),
+            make_toml("rule-x", "global", "x"),
+        )
+        .unwrap();
+
+        let after = scan_mtime(tmp.path().join("learnings").as_path());
+        assert_ne!(before, after);
+    }
+}

--- a/src/learnings/types.rs
+++ b/src/learnings/types.rs
@@ -1,0 +1,237 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::PathBuf;
+
+// ── Scope ────────────────────────────────────────────────────────
+
+/// Where and when a learning is injected.
+///
+/// - `Global`  — always injected into the system prompt
+/// - `Skill`   — injected alongside a specific skill's instructions
+/// - `Channel` — injected when a message arrives from a matching channel/chat
+/// - `Hook`    — injected at a named hook point (e.g. `on_message_received`,
+///               `before_tool_call`)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LearningScope {
+    /// Always active — injected into every system prompt.
+    Global,
+
+    /// Activate only when the named skill appears in the active skills list.
+    ///
+    /// Value is the skill name (e.g. `"feature-pr"`).
+    Skill { skill: String },
+
+    /// Activate when the inbound message originates from a matching channel.
+    ///
+    /// Value is a channel identifier string: `"slack:#channel-name"`,
+    /// `"discord:channel-id"`, `"telegram:chat-id"`, or a bare name for
+    /// provider-agnostic matching.
+    Channel { channel: String },
+
+    /// Activate at a named hook point.
+    ///
+    /// Value is the hook method name (e.g. `"before_tool_call"`,
+    /// `"on_message_received"`).  The learning text is appended to the prompt
+    /// immediately before the hook fires.
+    Hook { hook: String },
+}
+
+impl fmt::Display for LearningScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LearningScope::Global => write!(f, "global"),
+            LearningScope::Skill { skill } => write!(f, "skill:{skill}"),
+            LearningScope::Channel { channel } => write!(f, "channel:{channel}"),
+            LearningScope::Hook { hook } => write!(f, "hook:{hook}"),
+        }
+    }
+}
+
+// ── Learning ─────────────────────────────────────────────────────
+
+/// A single learning — a soft behavioral rule applied at a specific scope.
+///
+/// Learnings live in `<workspace>/learnings/<name>/LEARNING.toml` (+ optional
+/// `LEARNING.md` for long-form rule text).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Learning {
+    pub name: String,
+    pub description: String,
+
+    #[serde(default = "default_version")]
+    pub version: String,
+
+    #[serde(default)]
+    pub author: Option<String>,
+
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    /// One or more scopes — a learning can apply in multiple contexts.
+    pub scopes: Vec<LearningScope>,
+
+    /// The actual behavioral rules/instructions.
+    #[serde(default)]
+    pub rules: Vec<String>,
+
+    /// Filesystem location of the LEARNING.toml (not serialized to TOML).
+    #[serde(skip)]
+    pub location: Option<PathBuf>,
+}
+
+fn default_version() -> String {
+    "0.1.0".to_string()
+}
+
+// ── Manifest (LEARNING.toml on disk) ─────────────────────────────
+
+/// Top-level LEARNING.toml structure.
+#[derive(Debug, Deserialize)]
+pub(crate) struct LearningManifest {
+    pub learning: LearningMeta,
+    #[serde(default)]
+    pub rules: Vec<LearningRule>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LearningMeta {
+    pub name: String,
+    pub description: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Convenience single-scope shorthand.
+    #[serde(default)]
+    pub scope: Option<ScopeShorthand>,
+    /// Multi-scope list (preferred for learnings with multiple contexts).
+    #[serde(default)]
+    pub scopes: Vec<ScopeShorthand>,
+}
+
+/// A rule entry inside `[[rules]]`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct LearningRule {
+    pub content: String,
+}
+
+/// Human-readable scope string parsed from TOML.
+///
+/// Accepted formats:
+///   `"global"`, `"skill:feature-pr"`, `"channel:slack:#dev"`,
+///   `"hook:before_tool_call"`
+#[derive(Debug, Clone, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct ScopeShorthand(pub String);
+
+impl ScopeShorthand {
+    pub fn parse(&self) -> Option<LearningScope> {
+        parse_scope_shorthand(&self.0)
+    }
+}
+
+pub(crate) fn parse_scope_shorthand(s: &str) -> Option<LearningScope> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("global") {
+        return Some(LearningScope::Global);
+    }
+    if let Some(rest) = s.strip_prefix("skill:") {
+        if !rest.is_empty() {
+            return Some(LearningScope::Skill {
+                skill: rest.to_string(),
+            });
+        }
+    }
+    if let Some(rest) = s.strip_prefix("channel:") {
+        if !rest.is_empty() {
+            return Some(LearningScope::Channel {
+                channel: rest.to_string(),
+            });
+        }
+    }
+    if let Some(rest) = s.strip_prefix("hook:") {
+        if !rest.is_empty() {
+            return Some(LearningScope::Hook {
+                hook: rest.to_string(),
+            });
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_global_scope() {
+        assert_eq!(parse_scope_shorthand("global"), Some(LearningScope::Global));
+        assert_eq!(parse_scope_shorthand("GLOBAL"), Some(LearningScope::Global));
+    }
+
+    #[test]
+    fn parse_skill_scope() {
+        assert_eq!(
+            parse_scope_shorthand("skill:feature-pr"),
+            Some(LearningScope::Skill {
+                skill: "feature-pr".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_channel_scope() {
+        assert_eq!(
+            parse_scope_shorthand("channel:slack:#sct-internal-dev"),
+            Some(LearningScope::Channel {
+                channel: "slack:#sct-internal-dev".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_hook_scope() {
+        assert_eq!(
+            parse_scope_shorthand("hook:before_tool_call"),
+            Some(LearningScope::Hook {
+                hook: "before_tool_call".into()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_invalid_scope_returns_none() {
+        assert_eq!(parse_scope_shorthand("unknown:foo"), None);
+        assert_eq!(parse_scope_shorthand("skill:"), None);
+        assert_eq!(parse_scope_shorthand(""), None);
+    }
+
+    #[test]
+    fn display_scope() {
+        assert_eq!(LearningScope::Global.to_string(), "global");
+        assert_eq!(
+            LearningScope::Skill {
+                skill: "gh-issues".into()
+            }
+            .to_string(),
+            "skill:gh-issues"
+        );
+        assert_eq!(
+            LearningScope::Channel {
+                channel: "slack:#dev".into()
+            }
+            .to_string(),
+            "channel:slack:#dev"
+        );
+        assert_eq!(
+            LearningScope::Hook {
+                hook: "on_message_received".into()
+            }
+            .to_string(),
+            "hook:on_message_received"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) mod heartbeat;
 pub mod hooks;
 pub(crate) mod identity;
 pub(crate) mod integrations;
+pub(crate) mod learnings;
 pub mod memory;
 pub(crate) mod migration;
 pub(crate) mod multimodal;


### PR DESCRIPTION
## Summary

Introduces **Learnings** — a first-class layer of soft behavioral rules that sits between identity (SOUL.md/AGENTS.md) and skills/SOPs.

Full design proposal: `docs/design/learnings-system.md`

---

## The Gap Being Filled

| Layer | What it is | Where |
|---|---|---|
| Identity | Who the agent *is* | SOUL.md, AGENTS.md, AiEOS |
| Skills | What the agent *can do* | `workspace/skills/` |
| **Learnings** ← new | How the agent *should behave* in context | `workspace/learnings/` |
| SOPs | Triggered procedures | `workspace/sops/` |

---

## Scope Model

Each learning declares one or more scopes that control *when* its rules are injected:

| Scope | When injected |
|---|---|
| `global` | Every system prompt |
| `skill:<name>` | Alongside that skill's instructions |
| `channel:<id>` | When message originates from a matching channel |
| `hook:<name>` | At a named lifecycle hook point |

---

## Examples

**Draft PRs first (skill-scoped):**
```toml
[learning]
name  = "draft-pr-first"
scope = "skill:feature-pr"

[[rules]]
content = "Always create PRs as drafts. Do not promote without explicit human approval."
```

**Channel context (channel-scoped):**
```toml
[learning]
name  = "sct-dev-context"
scope = "channel:slack:#sct-internal-dev"

[[rules]]
content = "When a request is ambiguous, assume it relates to the buysidehub-api repository."
```

---

## What Changed

### New module: `src/learnings/`
- `types.rs` — `Learning`, `LearningScope`, manifest parsing
- `mod.rs` — `load_learnings()`, filter helpers (`global_learnings`, `learnings_for_skill`, `learnings_for_channel`, `learnings_for_hook`), prompt renderer

### `src/agent/prompt.rs`
- `PromptContext` gains `learnings: &[Learning]` + `active_channel: Option<&str>`
- New `GlobalLearningsSection` — injects `scope=Global` learnings after `SkillsSection`
- New `ChannelLearningsSection` — injects channel-matched learnings

### `src/agent/agent.rs`
- `Agent` + `AgentBuilder` gain `learnings` field
- `build_system_prompt_with_channel(active_channel)` — passes channel context into prompt build so channel-scoped learnings work correctly

### `src/hooks/builtin/learnings.rs`
- `LearningsHookHandler` — implements `before_prompt_build` to append `hook:before_prompt_build` learnings at request time

### `src/config/schema.rs`
- New `LearningsConfig` / `[learnings]` section (`enabled`, `dir`)

---

## Injection Lifecycle

```
Inbound message (e.g. Slack #sct-internal-dev)
  └─ channel id extracted: "slack:#sct-internal-dev"

Agent::build_system_prompt_with_channel("slack:#sct-internal-dev")
  ├─ IdentitySection
  ├─ ToolsSection
  ├─ SafetySection
  ├─ SkillsSection  ← skill-scoped learnings injected inline per-skill
  ├─ GlobalLearningsSection    ← scope=Global
  ├─ ChannelLearningsSection   ← scope=Channel("slack:#sct-internal-dev")
  ├─ WorkspaceSection
  ├─ ...
  └─ ChannelMediaSection

HookRunner::run_before_prompt_build(prompt)
  └─ LearningsHookHandler::before_prompt_build()
     └─ appends scope=Hook("before_prompt_build") learnings
```

---

## Not Done Yet (follow-on)

- `zeroclaw learnings list/validate/show` CLI subcommand
- Skill-scoped injection in `Compact` mode (currently only `Full` mode has inline skill learnings)
- Learning priority field
- Agent-to-agent approval patterns as a learning attribute
- Wire `active_channel` into gateway/daemon request path (currently defaults to `None` until channel propagation is threaded through)

---

## Design Doc

See [`docs/design/learnings-system.md`](docs/design/learnings-system.md) for full rationale, architecture diagrams, and worked examples.